### PR TITLE
fix unchecking assets at limit

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -283,7 +283,11 @@ export class ImagePickerCarousel extends Component<ImagePickerCarouselProps> {
   }
 
   selectedImage(checked: boolean, selected: SelectedAsset) {
-    if (this.props.max && this.state.selectedAssets.size >= this.props.max) {
+    if (
+      this.props.max &&
+      this.state.selectedAssets.size >= this.props.max &&
+      checked
+    ) {
       return false
     }
     if (!this.props.multiple) {


### PR DESCRIPTION
The assets were unselectable when at limit. You had to refresh the app to reset the selected assets in order to change them